### PR TITLE
Support ICM-42370-P

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -5,7 +5,7 @@ if(CONFIG_TDK_HAL)
 
   zephyr_library()
 
-  if(CONFIG_USE_EMD_ICM42670)
+  if(CONFIG_USE_EMD_ICM42670 OR CONFIG_USE_EMD_ICM42370)
 
     zephyr_include_directories(
       common

--- a/README.md
+++ b/README.md
@@ -9,3 +9,10 @@ This repository contains 6-Axis MEMS Motion Sensors drivers for:
 
 Find more information and product details here: 
 https://invensense.tdk.com/products/motion-tracking/6-axis/
+
+This repository contains 3-Axis MEMS Motion Sensors drivers for:
+
+* ICM-42370-P
+
+Find more information and product details here: 
+https://invensense.tdk.com/products/motion-tracking/3-axis/

--- a/icm42x7x/icm42x7x_h/imu/inv_imu.h
+++ b/icm42x7x/icm42x7x_h/imu/inv_imu.h
@@ -26,9 +26,18 @@ extern "C" {
 #define INV_ICM42670S_STRING_ID         "ICM42670S"
 #define INV_ICM42670S_WHOAMI            0x69
 
+/* Device description ICM42370P */
+#define INV_ICM42370P_STRING_ID         "ICM42370P"
+#define INV_ICM42370P_WHOAMI            0x0D
+
 #define INV_IMU_REV                     INV_IMU_REV_A
-#define INV_IMU_IS_GYRO_SUPPORTED       1
 #define INV_IMU_HFSR_SUPPORTED          0
+
+#if CONFIG_USE_EMD_ICM42670
+  #define INV_IMU_IS_GYRO_SUPPORTED     1
+#else /* USE_EMD_ICM42370 */
+  #define INV_IMU_IS_GYRO_SUPPORTED     0
+#endif
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
Drivers are the same, only update the inv_imu.h to handle INV_IMU_IS_GYRO_SUPPORTED define
Add CONFIG_USE_EMD_ICM42370 enabled according to device tree selection => icm42370p

Testing done: 
- integration in zephyr project with icm42370p support, run accel_trig sample ok